### PR TITLE
chore: update circuits to v2

### DIFF
--- a/circuits/rln-base.circom
+++ b/circuits/rln-base.circom
@@ -13,19 +13,6 @@ template CalculateIdentityCommitment() {
     out <== hasher.out;
 }
 
-template CalculateExternalNullifier() {
-    signal input epoch;
-    signal input rln_identifier;
-
-    signal output out;
-
-    component hasher = Poseidon(2);
-    hasher.inputs[0] <== epoch;
-    hasher.inputs[1] <== rln_identifier;
-
-    out <== hasher.out;
-}
-
 template CalculateA1() {
     signal input a_0;
     signal input external_nullifier;
@@ -61,8 +48,7 @@ template RLN(n_levels) {
 
     // public signals
     signal input x; // x is actually just the signal hash
-    signal input epoch;
-    signal input rln_identifier;
+    signal input external_nullifier;
 
     // outputs
     signal output y;
@@ -92,18 +78,14 @@ template RLN(n_levels) {
     // 2. Part
     // Line Equation Constraints
     //
-    // external_nullifier = Poseidon([epoch, rln_identifier])
     // a_1 = Poseidon([a_0, external_nullifier])
     // internal_nullifier = Poseidon([a_1])
     // 
     // share_y == a_0 + a_1 * x
-    component external_nullifier = CalculateExternalNullifier();
-    external_nullifier.epoch <== epoch;
-    external_nullifier.rln_identifier <== rln_identifier;
 
     component a_1 = CalculateA1();
     a_1.a_0 <== identity_secret;
-    a_1.external_nullifier <== external_nullifier.out;
+    a_1.external_nullifier <== external_nullifier;
 
     y <== identity_secret + a_1.out * x;
     component calculateNullifier = CalculateInternalNullifier();

--- a/circuits/rln.circom
+++ b/circuits/rln.circom
@@ -2,4 +2,4 @@ pragma circom 2.0.0;
 
 include "./rln-base.circom";
 
-component main {public [x, epoch, rln_identifier ]} = RLN(15);
+component main { public [x, external_nullifier] } = RLN(15);


### PR DESCRIPTION
In the opened issue #3 - updates we need to make were discussed.
This PR is an update to the first version where `external_nullifier` is a public input (correspondingly computed outside of snark). 

The PR aimed to update the circuits for the **1 degree polynomial case**.