### PR TITLE
Mitigate algebraic attacks in RLN

### DIFF
--- a/circuits/rln-base.circom
+++ b/circuits/rln-base.circom
@@ -2,6 +2,7 @@ pragma circom 2.0.0;
 
 include "./incrementalMerkleTree.circom";
 include "../node_modules/circomlib/circuits/poseidon.circom";
+include "../node_modules/circomlib/circuits/comparators.circom";
 
 template CalculateIdentityCommitment() {
     signal input identity_secret;
@@ -35,8 +36,53 @@ template CalculateA1() {
     component hasher = Poseidon(2);
     hasher.inputs[0] <== a_0;
     hasher.inputs[1] <== external_nullifier;
+    var hash = hasher.out;
 
-    out <== hasher.out;
+    // At this point we have hash = Poseidon([a0, external_nullifier])
+    // However hash = f(a0) only depends on the secret value a0, and its value can be 
+    // represented by a set of polynomials that might allow an attacker to successfuly
+    // recover a0 from shares
+
+    // To avoid this, we deterministically randomize the value of a1
+    // from hash to (hash % p1)*(hash % p2)
+    // Intuitively, this corresponds to introducing two new variables x1, x2 so that
+    // a1 = (f(a0) - x1*p1)*(f(a0) - x2*p2) % p = g(a0, x1, x2) % p
+    // and this will prevent any algebraic attacks over a single share.
+    // We note that the actual values of x1, x2 in the share computation will randomly change at each epoch
+    
+    // Few other observations:
+    //  i) p1,p2 are chosen so that p1*p2 = p-1. In this way the final bitsize of a1 does not look biased
+    // ii) We chose to use two p1 ~ p2 reductions instead of a single p0 ~ p, because otherwise we increase the probability that f(a0) < p0 (or they differs by few multiples of p0) and so a1 = f(a0) or a1 = f(a0) + r*p0 with small and guessable r.
+
+    // Here p1*p2 == p-1
+    var p1 = 144482646498173195876660926226499076096;
+    var p2 = 151493922642924629324195768596320362496;
+    
+    // We compute hash % p1
+    signal q1;
+    signal r1;
+    r1 <-- hash % p1;
+    q1 <-- hash \ p1;
+    hasher.out === q1*p1 + r1;
+    // We ensure that r1 < p1
+    component lt1 = LessThan(127); // Both p1 and p2 are 127 bits long  
+    lt1.in[0] <== r1;
+    lt1.in[1] <== p1;
+    lt1.out === 1;
+
+    // We compute hash % p2
+    signal q2;
+    signal r2;
+    r2 <-- hash % p2;
+    q2 <-- hash \ p2;
+    hasher.out === q2*p2 + r2;
+    // We ensure that r2 < p2
+    component lt2 = LessThan(127); // Both p1 and p2 are 127 bits long
+    lt2.in[0] <== r2;
+    lt2.in[1] <== p2;
+    lt2.out === 1;
+
+    out <== r1*r2;
 }
 
 template CalculateInternalNullifier() {


### PR DESCRIPTION
This PR proposes a circuit revision to mitigate possible algebraic attacks that recovers `a0` from shares computed at different epochs.

The main idea is to change `a1 = Poseidon([a0, external_nullifier])` (whose value only depends on `a0`) to

```
hash = Poseidon([a0, external_nullifier])
a1 =  (hash % p1)*(hash % p2) % p
```
Intuitively, this corresponds to introducing two new variables `x1`, `x2` so that `a1 = (hash - x1*p1)*(hash - x2*p2)`. In this way,`a1` can be expressed by a polynomial with at least 3 variables (i..e `a0, x1, x2`), preventing algebraic attacks working with a single share generated with respect to a certain epoch (the polynomial system is under-determined).

Since the actual values assigned to `x1, x2` to solve the share equation will randomly change at each epoch, this means that at each epoch two new independent variables `x1, x2` needs to be introduced to model with polynomials shares coming from different epoch. This fact keeps the polynomial system obtained combining shares coming from different epochs under-determined, preventing solving for `a0` using algebraic tools.

Few other observations related to such design choice:
- `p1` and `p2` are chosen so that `p1*p2 = p-1`. In this way the final bit-size of `a1` does not look biased [^2];
- We chose to use two `p1 ~ p2`[^1] reductions instead of a single `p0 ~ p`[^1], because otherwise we increase the probability that `hash < p0` or `hash` differs by few multiples of `p0` from `hash % p0` , in which case `a1 = f(a0)` or `a1 = f(a0) + r*p0` with small and guessable `r` (i.e. `a1` can be expressed by a polynomial in the single unknown `a0`).

The changes implemented in this PR increases the number of constraints by 4.6%, for a total of 5779 (originally 5524).

Any feedback is welcome!

### **DISCLAIMER: This proposal is currently under exploration and did not go through an extensive security analysis yet.**

[^1]: `a ~ b` means `a` and `b` have similar bit-size.
[^2]: there is no strict requirement for `p1*p2 = p-1`. Actually, to allow the system to have infinite solutions in `a0,x1,x2` at each epoch, it seems necessary for  `p1,p2` to be coprime and we can also impose `p1*p2 > p` (overflows will be absorbed by the underlying modulo `p` field arithmetic), given that `p1,p2 < p`. The choice of such parameters has to be investigated further.


